### PR TITLE
Fix suggestions text padding

### DIFF
--- a/java/res/values/themes-common.xml
+++ b/java/res/values/themes-common.xml
@@ -114,9 +114,9 @@
         <item name="android:minWidth">@dimen/config_suggestion_min_width</item>
         <item name="android:textSize">@dimen/config_suggestion_text_size</item>
         <item name="android:gravity">center</item>
-        <item name="android:paddingStart">@dimen/config_suggestion_text_horizontal_padding</item>
+        <item name="android:paddingLeft">@dimen/config_suggestion_text_horizontal_padding</item>
         <item name="android:paddingTop">0dp</item>
-        <item name="android:paddingEnd">@dimen/config_suggestion_text_horizontal_padding</item>
+        <item name="android:paddingRight">@dimen/config_suggestion_text_horizontal_padding</item>
         <item name="android:paddingBottom">0dp</item>
         <!-- Provide audio and haptic feedback by ourselves based on the keyboard settings.
              We just need to ignore the system's audio and haptic feedback settings. -->


### PR DESCRIPTION
Use paddingLeft and paddingRight (as Google Keyboard does) instead of paddingStart and paddingEnd to fix text padding in suggestions bar.

Before: http://goo.gl/ZjN06c
After: http://goo.gl/s8f7gr
